### PR TITLE
fix(cf-calculator): Fix display of number of quests when infinite generator

### DIFF
--- a/components/cf-calculator/script.js
+++ b/components/cf-calculator/script.js
@@ -243,6 +243,7 @@ export default {
           value: val
         });
         this.$data.infinityGenerator = false;
+        this.$data.cumulativeQuest = 0;
         this.calculate();
       }
     },

--- a/components/cf-calculator/template.pug
+++ b/components/cf-calculator/template.pug
@@ -70,7 +70,7 @@ div
         p {{$t(i18nPrefix + 'block_cfc.reward_message.bonus_ubq', {count: result.bonusUbq})}}
     div.column.is-one-third
       div.field
-        p {{$t(i18nPrefix + 'block_cfc.reward_message.total_rq_completed', {count: result.totalRqCompleted})}}
+        p {{$t(i18nPrefix + 'block_cfc.reward_message.total_rq_completed', {count: infinityGenerator ? cumulativeQuest : result.totalRqCompleted})}}
         p(v-show="secondRq") {{$t(i18nPrefix + 'block_cfc.reward_message.second_rq_completed', {count: result.secondRqCompleted})}}
 
   div.table-wrapper(v-show="!result.coinSupplyReturn.length <= 0")


### PR DESCRIPTION
Also fix infinite loop when number of quests set for infinite generator
is greeter than quests can be done after changing the CF bonus (and this
new value is not an infinite generator)