### PR TITLE
feat(foe-data): :package: Add levels of several ages

### DIFF
--- a/lib/foe-data/ages-cost/BronzeAge.js
+++ b/lib/foe-data/ages-cost/BronzeAge.js
@@ -153,5 +153,6 @@ module.exports = [
   { cost: 16178, reward: generateReward(1400) },
   { cost: 16582, reward: generateReward(1415) },
   { cost: 16997, reward: generateReward(1425) },
-  { cost: 17422, reward: generateReward(1435) }
+  { cost: 17422, reward: generateReward(1435) },
+  { cost: 17857, reward: generateReward(1445) }
 ];

--- a/lib/foe-data/ages-cost/IndustrialAge.js
+++ b/lib/foe-data/ages-cost/IndustrialAge.js
@@ -101,5 +101,6 @@ module.exports = [
   { cost: 6940, reward: generateReward(1300) },
   { cost: 7113, reward: generateReward(1315) },
   { cost: 7291, reward: generateReward(1330) },
-  { cost: 7474, reward: generateReward(1345) }
+  { cost: 7474, reward: generateReward(1345) },
+  { cost: 7660, reward: generateReward(1360) }
 ];

--- a/lib/foe-data/ages-cost/IronAge.js
+++ b/lib/foe-data/ages-cost/IronAge.js
@@ -103,5 +103,6 @@ module.exports = [
   { cost: 5076, reward: generateReward(940) },
   { cost: 5203, reward: generateReward(950) },
   { cost: 5333, reward: generateReward(960) },
-  { cost: 5467, reward: generateReward(975) }
+  { cost: 5467, reward: generateReward(975) },
+  { cost: 5603, reward: generateReward(985) }
 ];

--- a/lib/foe-data/ages-cost/LateMiddleAges.js
+++ b/lib/foe-data/ages-cost/LateMiddleAges.js
@@ -130,5 +130,7 @@ module.exports = [
   { cost: 12584, reward: generateReward(1565) },
   { cost: 12898, reward: generateReward(1580) },
   { cost: 13221, reward: generateReward(1595) },
-  { cost: 13551, reward: generateReward(1610) }
+  { cost: 13551, reward: generateReward(1610) },
+  { cost: 13890, reward: generateReward(1625) },
+  { cost: 14237, reward: generateReward(1640) }
 ];

--- a/lib/foe-data/ages-cost/OceanicFuture.js
+++ b/lib/foe-data/ages-cost/OceanicFuture.js
@@ -110,5 +110,6 @@ module.exports = [
   { cost: 12726, reward: generateReward(2120) },
   { cost: 13044, reward: generateReward(2145) },
   { cost: 13370, reward: generateReward(2170) },
-  { cost: 13704, reward: generateReward(2190) }
+  { cost: 13704, reward: generateReward(2190) },
+  { cost: 14047, reward: generateReward(2215) }
 ];

--- a/lib/foe-data/ages-cost/VirtualFuture.js
+++ b/lib/foe-data/ages-cost/VirtualFuture.js
@@ -106,5 +106,6 @@ module.exports = [
   { cost: 12026, reward: generateReward(2105) },
   { cost: 12327, reward: generateReward(2130) },
   { cost: 12635, reward: generateReward(2155) },
-  { cost: 12951, reward: generateReward(2180) }
+  { cost: 12951, reward: generateReward(2180) },
+  { cost: 13274, reward: generateReward(2205) }
 ];


### PR DESCRIPTION
Add GB levels (cost and reward) of:
- Bronze Age: 154
- Iron Age: 104
- Late Middle Ages: 130 to 132
- Industrial Age: 102
- Oceanic Future: 111
- Virtual Future: 107