### PR TITLE
Add levels of several ages

### DIFF
--- a/.scripts/config.json
+++ b/.scripts/config.json
@@ -1,18 +1,18 @@
 {
-  "BronzeAge": 155,
+  "BronzeAge": 156,
   "IronAge": 105,
-  "EarlyMiddleAges": 131,
+  "EarlyMiddleAges": 132,
   "HighMiddleAges": 98,
-  "LateMiddleAges": 134,
+  "LateMiddleAges": 137,
   "ColonialAge": 101,
   "IndustrialAge": 103,
-  "ProgressiveEra": 167,
+  "ProgressiveEra": 168,
   "ModernEra": 101,
   "PostmodernEra": 136,
   "ContemporaryEra": 121,
   "Tomorrow": 102,
   "TheFuture": 183,
   "ArcticFuture": 137,
-  "OceanicFuture": 112,
+  "OceanicFuture": 113,
   "VirtualFuture": 112
 }

--- a/lib/foe-data/ages-cost/BronzeAge.js
+++ b/lib/foe-data/ages-cost/BronzeAge.js
@@ -155,5 +155,6 @@ module.exports = [
   { cost: 16997, reward: generateReward(1425) },
   { cost: 17422, reward: generateReward(1435) },
   { cost: 17857, reward: generateReward(1445) },
-  { cost: 18304, reward: generateReward(1460) }
+  { cost: 18304, reward: generateReward(1460) },
+  { cost: 18761, reward: generateReward(1470) },
 ];

--- a/lib/foe-data/ages-cost/EarlyMiddleAges.js
+++ b/lib/foe-data/ages-cost/EarlyMiddleAges.js
@@ -131,5 +131,6 @@ module.exports = [
   { cost: 11056, reward: generateReward(1370) },
   { cost: 11332, reward: generateReward(1380) },
   { cost: 11615, reward: generateReward(1395) },
-  { cost: 11906, reward: generateReward(1405) }
+  { cost: 11906, reward: generateReward(1405) },
+  { cost: 12203, reward: generateReward(1420) },
 ];

--- a/lib/foe-data/ages-cost/LateMiddleAges.js
+++ b/lib/foe-data/ages-cost/LateMiddleAges.js
@@ -134,5 +134,8 @@ module.exports = [
   { cost: 13890, reward: generateReward(1625) },
   { cost: 14237, reward: generateReward(1640) },
   { cost: 14593, reward: generateReward(1655) },
-  { cost: 14958, reward: generateReward(1670) }
+  { cost: 14958, reward: generateReward(1670) },
+  { cost: 15332, reward: generateReward(1685) },
+  { cost: 15715, reward: generateReward(1700) },
+  { cost: 16108, reward: generateReward(1715) },
 ];

--- a/lib/foe-data/ages-cost/OceanicFuture.js
+++ b/lib/foe-data/ages-cost/OceanicFuture.js
@@ -112,5 +112,6 @@ module.exports = [
   { cost: 13370, reward: generateReward(2170) },
   { cost: 13704, reward: generateReward(2190) },
   { cost: 14047, reward: generateReward(2215) },
-  { cost: 14398, reward: generateReward(2240) }
+  { cost: 14398, reward: generateReward(2240) },
+  { cost: 14758, reward: generateReward(2265) },
 ];

--- a/lib/foe-data/ages-cost/ProgressiveEra.js
+++ b/lib/foe-data/ages-cost/ProgressiveEra.js
@@ -167,5 +167,6 @@ module.exports = [
   { cost: 37201, reward: generateReward(2555) },
   { cost: 38131, reward: generateReward(2570) },
   { cost: 39085, reward: generateReward(2590) },
-  { cost: 40062, reward: generateReward(2610) }
+  { cost: 40062, reward: generateReward(2610) },
+  { cost: 41063, reward: generateReward(2630) },
 ];


### PR DESCRIPTION
Add GB levels (cost and reward) of:
- Bronze Age: 156
- Early Middle Ages: 132
- Late Middle Ages: 135 to 137
- Progressive Era: 168
- Oceanic Future: 113