### PR TITLE
Add levels of several ages

### DIFF
--- a/.scripts/config.json
+++ b/.scripts/config.json
@@ -2,11 +2,11 @@
   "BronzeAge": 156,
   "IronAge": 105,
   "EarlyMiddleAges": 132,
-  "HighMiddleAges": 98,
-  "LateMiddleAges": 137,
+  "HighMiddleAges": 99,
+  "LateMiddleAges": 138,
   "ColonialAge": 101,
   "IndustrialAge": 103,
-  "ProgressiveEra": 168,
+  "ProgressiveEra": 169,
   "ModernEra": 101,
   "PostmodernEra": 136,
   "ContemporaryEra": 121,
@@ -14,5 +14,5 @@
   "TheFuture": 183,
   "ArcticFuture": 137,
   "OceanicFuture": 113,
-  "VirtualFuture": 112
+  "VirtualFuture": 114
 }

--- a/lib/foe-data/ages-cost/LateMiddleAges.js
+++ b/lib/foe-data/ages-cost/LateMiddleAges.js
@@ -137,5 +137,6 @@ module.exports = [
   { cost: 14958, reward: generateReward(1670) },
   { cost: 15332, reward: generateReward(1685) },
   { cost: 15715, reward: generateReward(1700) },
-  { cost: 16108, reward: generateReward(1715) }
+  { cost: 16108, reward: generateReward(1715) },
+  { cost: 16511, reward: generateReward(1730) },
 ];

--- a/lib/foe-data/ages-cost/ProgressiveEra.js
+++ b/lib/foe-data/ages-cost/ProgressiveEra.js
@@ -168,5 +168,6 @@ module.exports = [
   { cost: 38131, reward: generateReward(2570) },
   { cost: 39085, reward: generateReward(2590) },
   { cost: 40062, reward: generateReward(2610) },
-  { cost: 41063, reward: generateReward(2630) }
+  { cost: 41063, reward: generateReward(2630) },
+  { cost: 42090, reward: generateReward(2645) },
 ];

--- a/lib/foe-data/ages-cost/VirtualFuture.js
+++ b/lib/foe-data/ages-cost/VirtualFuture.js
@@ -112,5 +112,7 @@ module.exports = [
   { cost: 13946, reward: generateReward(2255) },
   { cost: 14295, reward: generateReward(2280) },
   { cost: 14652, reward: generateReward(2305) },
-  { cost: 15019, reward: generateReward(2330) }
+  { cost: 15019, reward: generateReward(2330) },
+  { cost: 15394, reward: generateReward(2355) },
+  { cost: 15779, reward: generateReward(2380) },
 ];

--- a/lib/foe-data/ages-cost/defaultCost.js
+++ b/lib/foe-data/ages-cost/defaultCost.js
@@ -98,5 +98,6 @@ module.exports = [
   { cost: 6622, reward: generateReward(1150) },
   { cost: 6788, reward: generateReward(1160) },
   { cost: 6957, reward: generateReward(1175) },
-  { cost: 7131, reward: generateReward(1190) }
+  { cost: 7131, reward: generateReward(1190) },
+  { cost: 7309, reward: generateReward(1200) },
 ];


### PR DESCRIPTION
Add GB levels (cost and reward) of:
- High Middle Ages / No Age: 99
- Late Middle Ages: 138
- Progressive Era: 169
- Virtual Future: 113 to 114