### PR TITLE
Add levels of several ages

### DIFF
--- a/.scripts/config.json
+++ b/.scripts/config.json
@@ -3,7 +3,7 @@
   "IronAge": 105,
   "EarlyMiddleAges": 132,
   "HighMiddleAges": 99,
-  "LateMiddleAges": 138,
+  "LateMiddleAges": 139,
   "ColonialAge": 101,
   "IndustrialAge": 103,
   "ProgressiveEra": 169,
@@ -14,5 +14,5 @@
   "TheFuture": 183,
   "ArcticFuture": 137,
   "OceanicFuture": 113,
-  "VirtualFuture": 114
+  "VirtualFuture": 116
 }

--- a/lib/foe-data/ages-cost/LateMiddleAges.js
+++ b/lib/foe-data/ages-cost/LateMiddleAges.js
@@ -138,5 +138,6 @@ module.exports = [
   { cost: 15332, reward: generateReward(1685) },
   { cost: 15715, reward: generateReward(1700) },
   { cost: 16108, reward: generateReward(1715) },
-  { cost: 16511, reward: generateReward(1730) }
+  { cost: 16511, reward: generateReward(1730) },
+  { cost: 16923, reward: generateReward(1745) },
 ];

--- a/lib/foe-data/ages-cost/LateMiddleAges.js
+++ b/lib/foe-data/ages-cost/LateMiddleAges.js
@@ -139,5 +139,5 @@ module.exports = [
   { cost: 15715, reward: generateReward(1700) },
   { cost: 16108, reward: generateReward(1715) },
   { cost: 16511, reward: generateReward(1730) },
-  { cost: 16923, reward: generateReward(1745) },
+  { cost: 16923, reward: generateReward(1745) }
 ];

--- a/lib/foe-data/ages-cost/VirtualFuture.js
+++ b/lib/foe-data/ages-cost/VirtualFuture.js
@@ -114,5 +114,7 @@ module.exports = [
   { cost: 14652, reward: generateReward(2305) },
   { cost: 15019, reward: generateReward(2330) },
   { cost: 15394, reward: generateReward(2355) },
-  { cost: 15779, reward: generateReward(2380) }
+  { cost: 15779, reward: generateReward(2380) },
+  { cost: 16174, reward: generateReward(2405) },
+  { cost: 16578, reward: generateReward(2430) },
 ];

--- a/lib/foe-data/ages-cost/VirtualFuture.js
+++ b/lib/foe-data/ages-cost/VirtualFuture.js
@@ -116,5 +116,5 @@ module.exports = [
   { cost: 15394, reward: generateReward(2355) },
   { cost: 15779, reward: generateReward(2380) },
   { cost: 16174, reward: generateReward(2405) },
-  { cost: 16578, reward: generateReward(2430) },
+  { cost: 16578, reward: generateReward(2430) }
 ];


### PR DESCRIPTION
Add GB levels (cost and reward) of:
- Late Middle Ages: 139
- Virtual Future: 115 to 116