### PR TITLE
Enhancement promotion message + add levels

### DIFF
--- a/.scripts/config.json
+++ b/.scripts/config.json
@@ -1,19 +1,19 @@
 {
   "BronzeAge": 157,
-  "IronAge": 105,
+  "IronAge": 107,
   "EarlyMiddleAges": 133,
   "HighMiddleAges": 99,
-  "LateMiddleAges": 141,
-  "ColonialAge": 103,
+  "LateMiddleAges": 142,
+  "ColonialAge": 104,
   "IndustrialAge": 103,
-  "ProgressiveEra": 171,
+  "ProgressiveEra": 172,
   "ModernEra": 101,
   "PostmodernEra": 136,
   "ContemporaryEra": 121,
-  "Tomorrow": 102,
+  "Tomorrow": 103,
   "TheFuture": 183,
   "ArcticFuture": 137,
-  "OceanicFuture": 114,
+  "OceanicFuture": 115,
   "VirtualFuture": 118,
-  "SpaceAgeMars": 83
+  "SpaceAgeMars": 89
 }

--- a/components/gb-investment/script.js
+++ b/components/gb-investment/script.js
@@ -26,6 +26,9 @@ const queryKey = {
   placeFree: urlPrefix + "pFree",
   prefix: urlPrefix + "px",
   suffix: urlPrefix + "sx",
+  displayGbName: urlPrefix + "dgbn",
+  shortName: urlPrefix + "sn",
+  showLevel: urlPrefix + "sl",
   showPrefix: urlPrefix + "spx",
   showSuffix: urlPrefix + "ssx",
   showSnipe: urlPrefix + "ss",
@@ -91,6 +94,10 @@ export default {
       placeFree: [{ state: true }, { state: true }, { state: true }, { state: true }, { state: true }],
       prefix: this.$cookies.get("gbPrefix") ? this.$cookies.get("gbPrefix") : "",
       suffix: this.$cookies.get("gbSuffix") ? this.$cookies.get("gbSuffix") : "",
+      displayGbName:
+        typeof this.$cookies.get("displayGbName") === "boolean" ? !!this.$cookies.get("displayGbName") : true,
+      shortName: typeof this.$cookies.get("shortName") === "boolean" ? !!this.$cookies.get("shortName") : false,
+      showLevel: typeof this.$cookies.get("showLevel") === "boolean" ? !!this.$cookies.get("showLevel") : true,
       showPrefix: typeof this.$cookies.get("gbShowPrefix") === "boolean" ? !!this.$cookies.get("gbShowPrefix") : true,
       showSuffix: typeof this.$cookies.get("gbShowSuffix") === "boolean" ? !!this.$cookies.get("gbShowSuffix") : true,
       yourArcBonus: this.$cookies.get("yourArcBonus") === undefined ? 0 : parseFloat(this.$cookies.get("yourArcBonus")),
@@ -188,6 +195,21 @@ export default {
     this.$store.commit("ADD_URL_QUERY", {
       key: queryKey.suffix,
       value: data.suffix,
+      ns: "gbi"
+    });
+    this.$store.commit("ADD_URL_QUERY", {
+      key: queryKey.shortName,
+      value: data.shortName ? 1 : 0,
+      ns: "gbi"
+    });
+    this.$store.commit("ADD_URL_QUERY", {
+      key: queryKey.displayGbName,
+      value: data.displayGbName ? 1 : 0,
+      ns: "gbi"
+    });
+    this.$store.commit("ADD_URL_QUERY", {
+      key: queryKey.showLevel,
+      value: data.showLevel ? 1 : 0,
       ns: "gbi"
     });
     this.$store.commit("ADD_URL_QUERY", {
@@ -441,6 +463,42 @@ export default {
       });
       this.updatePromotionMessage();
     },
+    displayGbName(val) {
+      this.$store.commit("UPDATE_URL_QUERY", {
+        key: queryKey.displayGbName,
+        value: val ? 1 : 0,
+        ns: "gbi"
+      });
+      this.$cookies.set("displayGbName", val, {
+        path: "/",
+        expires: Utils.getDefaultCookieExpireTime()
+      });
+      this.updatePromotionMessage();
+    },
+    shortName(val) {
+      this.$store.commit("UPDATE_URL_QUERY", {
+        key: queryKey.shortName,
+        value: val ? 1 : 0,
+        ns: "gbi"
+      });
+      this.$cookies.set("shortName", val, {
+        path: "/",
+        expires: Utils.getDefaultCookieExpireTime()
+      });
+      this.updatePromotionMessage();
+    },
+    showLevel(val) {
+      this.$store.commit("UPDATE_URL_QUERY", {
+        key: queryKey.showLevel,
+        value: val ? 1 : 0,
+        ns: "gbi"
+      });
+      this.$cookies.set("showLevel", val, {
+        path: "/",
+        expires: Utils.getDefaultCookieExpireTime()
+      });
+      this.updatePromotionMessage();
+    },
     showPrefix(val) {
       this.$store.commit("UPDATE_URL_QUERY", {
         key: queryKey.showPrefix,
@@ -569,7 +627,10 @@ export default {
             {
               ...promotion.config,
               prefix: this.showPrefix ? this.prefix : "",
-              suffix: this.showSuffix ? this.suffix : ""
+              suffix: this.showSuffix ? this.suffix : "",
+              displayGbName: this.displayGbName,
+              useShortGbName: this.shortName,
+              showLevel: this.showLevel
             },
             messageInterpolation,
             placesInterpolationValues
@@ -706,6 +767,21 @@ export default {
       if (this.$route.query[queryKey.suffix]) {
         isPermalink = true;
         result.suffix = this.$route.query[queryKey.suffix];
+      }
+
+      if (this.$route.query[queryKey.displayGbName]) {
+        isPermalink = true;
+        result.displayGbName = !!parseInt(this.$route.query[queryKey.displayGbName]);
+      }
+
+      if (this.$route.query[queryKey.shortName]) {
+        isPermalink = true;
+        result.shortName = !!parseInt(this.$route.query[queryKey.shortName]);
+      }
+
+      if (this.$route.query[queryKey.showLevel]) {
+        isPermalink = true;
+        result.showLevel = !!parseInt(this.$route.query[queryKey.showLevel]);
       }
 
       if (this.$route.query[queryKey.showPrefix]) {

--- a/components/gb-investment/template.pug
+++ b/components/gb-investment/template.pug
@@ -337,6 +337,16 @@ div.content
                     i.fas.fa-eye-slash
                     | &nbsp;&nbsp;&nbsp;
 
+      div.columns
+        div.column.is-half
+          div.columns
+            div.column.is-half
+              yes-no(v-model="displayGbName" :label="$t($data.i18nPrefix + 'gb_investment.display_gb_name')")
+            div.column.is-half(v-if="displayGbName")
+              yes-no(v-model="shortName" :label="$t($data.i18nPrefix + 'gb_investment.use_short_name')")
+        div.column.is-half
+          yes-no(v-model="showLevel" :label="$t($data.i18nPrefix + 'gb_investment.show_level')")
+
       div(v-if="result !== null")
         b-field(v-for="(value, i) in promotion" :key="i")
           p.control

--- a/lib/foe-data/ages-cost/ColonialAge.js
+++ b/lib/foe-data/ages-cost/ColonialAge.js
@@ -103,5 +103,6 @@ module.exports = [
   { cost: 6830, reward: generateReward(1250) },
   { cost: 7001, reward: generateReward(1265) },
   { cost: 7176, reward: generateReward(1280) },
-  { cost: 7355, reward: generateReward(1295) }
+  { cost: 7355, reward: generateReward(1295) },
+  { cost: 7539, reward: generateReward(1310) }
 ];

--- a/lib/foe-data/ages-cost/IronAge.js
+++ b/lib/foe-data/ages-cost/IronAge.js
@@ -105,5 +105,7 @@ module.exports = [
   { cost: 5333, reward: generateReward(960) },
   { cost: 5467, reward: generateReward(975) },
   { cost: 5603, reward: generateReward(985) },
-  { cost: 5743, reward: generateReward(995) }
+  { cost: 5743, reward: generateReward(995) },
+  { cost: 5887, reward: generateReward(1010) },
+  { cost: 6034, reward: generateReward(1020) }
 ];

--- a/lib/foe-data/ages-cost/LateMiddleAges.js
+++ b/lib/foe-data/ages-cost/LateMiddleAges.js
@@ -141,5 +141,6 @@ module.exports = [
   { cost: 16511, reward: generateReward(1730) },
   { cost: 16923, reward: generateReward(1745) },
   { cost: 17347, reward: generateReward(1760) },
-  { cost: 17780, reward: generateReward(1775) }
+  { cost: 17780, reward: generateReward(1775) },
+  { cost: 18225, reward: generateReward(1790) }
 ];

--- a/lib/foe-data/ages-cost/OceanicFuture.js
+++ b/lib/foe-data/ages-cost/OceanicFuture.js
@@ -114,5 +114,6 @@ module.exports = [
   { cost: 14047, reward: generateReward(2215) },
   { cost: 14398, reward: generateReward(2240) },
   { cost: 14758, reward: generateReward(2265) },
-  { cost: 15127, reward: generateReward(2290) }
+  { cost: 15127, reward: generateReward(2290) },
+  { cost: 15505, reward: generateReward(2310) }
 ];

--- a/lib/foe-data/ages-cost/ProgressiveEra.js
+++ b/lib/foe-data/ages-cost/ProgressiveEra.js
@@ -171,5 +171,6 @@ module.exports = [
   { cost: 41063, reward: generateReward(2630) },
   { cost: 42090, reward: generateReward(2645) },
   { cost: 43142, reward: generateReward(2665) },
-  { cost: 44221, reward: generateReward(2685) }
+  { cost: 44221, reward: generateReward(2685) },
+  { cost: 45326, reward: generateReward(2705) }
 ];

--- a/lib/foe-data/ages-cost/SpaceAgeMars.js
+++ b/lib/foe-data/ages-cost/SpaceAgeMars.js
@@ -83,5 +83,11 @@ module.exports = [
   { cost: 7041, reward: generateReward(1615) },
   { cost: 7217, reward: generateReward(1635) },
   { cost: 7397, reward: generateReward(1660) },
-  { cost: 7582, reward: generateReward(1685) }
+  { cost: 7582, reward: generateReward(1685) },
+  { cost: 7771, reward: generateReward(1710) },
+  { cost: 7966, reward: generateReward(1735) },
+  { cost: 8165, reward: generateReward(1760) },
+  { cost: 8369, reward: generateReward(1785) },
+  { cost: 8578, reward: generateReward(1810) },
+  { cost: 8793, reward: generateReward(1835) }
 ];

--- a/lib/foe-data/ages-cost/Tomorrow.js
+++ b/lib/foe-data/ages-cost/Tomorrow.js
@@ -102,5 +102,6 @@ module.exports = [
   { cost: 8374, reward: generateReward(1700) },
   { cost: 8583, reward: generateReward(1720) },
   { cost: 8798, reward: generateReward(1740) },
-  { cost: 9018, reward: generateReward(1760) }
+  { cost: 9018, reward: generateReward(1760) },
+  { cost: 9243, reward: generateReward(1780) }
 ];

--- a/locales/en.json
+++ b/locales/en.json
@@ -121,7 +121,10 @@
               "total_preparation": "Total investment of the owner",
               "level_cost": "Level cost"
             }
-          }
+          },
+          "display_gb_name": "Display GB name ?",
+          "use_short_name": "Use short name ?",
+          "show_level": "Show level ?"
         },
         "promotion": {
           "title": "Promotion message",
@@ -323,7 +326,7 @@
           "custom": "Custom templates"
         },
         "config": "Configuration",
-        "use_short_name": "Use short name ?",
+        "use_short_name": "$t(components.gb_investment.gb_investment.use_short_name)",
         "reverse_place_order": "Reverse places order ?",
         "place_separator": "Place separator",
         "place_builder": "Place builder",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -121,7 +121,10 @@
               "total_preparation": "Investissement total du propriétaire",
               "level_cost": "Coût du niveau"
             }
-          }
+          },
+          "display_gb_name": "Afficher le nom du GM ?",
+          "use_short_name": "Utiliser un nom court ?",
+          "show_level": "Afficher le niveau ?"
         },
         "promotion": {
           "title": "Message de promotion",
@@ -323,7 +326,7 @@
           "custom": "Modèles personnalisés"
         },
         "config": "Configuration",
-        "use_short_name": "Utiliser un nom court ?",
+        "use_short_name": "$t(components.gb_investment.gb_investment.use_short_name)",
         "reverse_place_order": "Inverser l'ordre des places ?",
         "place_separator": "Séparateur de place",
         "place_builder": "Constructeur de places",

--- a/scripts/promotion-message-builder.js
+++ b/scripts/promotion-message-builder.js
@@ -43,6 +43,15 @@ export function buildPlace(placeBuilder, interpolationValues) {
  */
 export function buildMessage(gbKey, data, interpolationValues, placeInterpolationValues) {
   let result = data.message;
+  const findLevelRange = /\s?\${(?:FLVL|TLVL)}[^(?<!${(?:FLVL|TLVL)})]*\${(?:FLVL|TLVL)}/gi;
+  if (!data.showLevel) {
+    if (findLevelRange.test(data.message)) {
+      result = result.replace(findLevelRange, "");
+    } else {
+      result = result.replace(/\s?\${(?:FLVL|TLVL)}/gi, "");
+    }
+  }
+
   let places = "";
   const goodPlaceInterpolationValues = data.reversePlacesOrder
     ? [...placeInterpolationValues].reverse()
@@ -53,14 +62,16 @@ export function buildMessage(gbKey, data, interpolationValues, placeInterpolatio
     }
   });
 
-  const goodInterpolationValues = [
-    ...interpolationValues,
-    {
+  const goodInterpolationValues = [...interpolationValues, { key: "P", value: places }];
+
+  if (data.displayGbName) {
+    goodInterpolationValues.push({
       key: "GBN",
       value: data.useShortGbName ? this.$t(`foe_data.gb_short.${gbKey}`) : this.$t(`foe_data.gb.${gbKey}`)
-    },
-    { key: "P", value: places }
-  ];
+    });
+  } else {
+    result = result.replace(/\${GBN}\s?/gi, "");
+  }
 
   goodInterpolationValues.forEach(interpolation => {
     result = result.replace(new RegExp(`\\\${${interpolation.key}}`, "gi"), interpolation.value);
@@ -83,6 +94,8 @@ export const defaultPromotionMessages = [
     config: {
       prefix: "",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: false,
       placeSeparator: " ",
@@ -95,6 +108,8 @@ export const defaultPromotionMessages = [
     config: {
       prefix: "",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: false,
       placeSeparator: " ",
@@ -107,6 +122,8 @@ export const defaultPromotionMessages = [
     config: {
       prefix: "",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: true,
       placeSeparator: " ",
@@ -119,6 +136,8 @@ export const defaultPromotionMessages = [
     config: {
       prefix: "",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: true,
       placeSeparator: " ",
@@ -131,6 +150,8 @@ export const defaultPromotionMessages = [
     config: {
       prefix: "",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: false,
       placeSeparator: " ",
@@ -143,6 +164,8 @@ export const defaultPromotionMessages = [
     config: {
       prefix: "",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: true,
       placeSeparator: " ",
@@ -155,6 +178,8 @@ export const defaultPromotionMessages = [
     config: {
       prefix: "",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: false,
       placeSeparator: ",",
@@ -167,11 +192,55 @@ export const defaultPromotionMessages = [
     config: {
       prefix: "",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: true,
       placeSeparator: ",",
       place: "${PI}",
       message: "${GBN} ${FLVL} → ${TLVL} ${P}"
+    }
+  },
+  {
+    name: "Default 9",
+    config: {
+      prefix: "",
+      suffix: "",
+      displayGbName: false,
+      showLevel: false,
+      useShortGbName: false,
+      reversePlacesOrder: true,
+      placeSeparator: ",",
+      place: "${PI}",
+      message: "${GBN} ${FLVL} → ${TLVL} ${P}"
+    }
+  },
+  {
+    name: "Default 10",
+    config: {
+      prefix: "",
+      suffix: "",
+      displayGbName: true,
+      showLevel: true,
+      useShortGbName: false,
+      reversePlacesOrder: true,
+      placeSeparator: ",",
+      place: "${PI}",
+      message: "${GBN} ${FLVL} → ${TLVL} ${P}"
+    }
+  },
+  {
+    name: "Custom 11",
+    config: {
+      prefix: "",
+      suffix: "",
+      displayGbName: true,
+      showLevel: true,
+      useShortGbName: false,
+      reversePlacesOrder: true,
+      placeSeparator: ",",
+      place: "${PI}",
+      message: "${GBN} ${FLVL} < ${P} > ${TLVL}"
     }
   }
 ];

--- a/test/unit/__snapshots__/components.test.js.snap
+++ b/test/unit/__snapshots__/components.test.js.snap
@@ -131,6 +131,18 @@ Array [
     "active": false,
     "message": "Observatory 9 → 10 4,3,2",
   },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 < 4,3,2 > 10",
+  },
 ]
 `;
 
@@ -192,6 +204,18 @@ Array [
   },
   Object {
     "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 < 4,3,2,1 > 10",
+  },
+  Object {
+    "active": false,
     "message": "P1(124) P2(67) P3(19) P4(10) Observatory 9 → 10",
   },
 ]
@@ -226,6 +250,18 @@ Array [
   Object {
     "active": false,
     "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 < 4,3,2,1 > 10",
   },
   Object {
     "active": false,
@@ -264,6 +300,18 @@ Array [
     "active": false,
     "message": "Observatory 9 → 10 4,3,2,1",
   },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 < 4,3,2,1 > 10",
+  },
 ]
 `;
 
@@ -296,6 +344,18 @@ Array [
   Object {
     "active": false,
     "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 < 4,3,2,1 > 10",
   },
   Object {
     "active": false,
@@ -333,6 +393,18 @@ Array [
   Object {
     "active": false,
     "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 < 4,3,2,1 > 10",
   },
   Object {
     "active": false,
@@ -375,6 +447,18 @@ Array [
     "active": false,
     "message": "Observatory 9 → 10 4,3,2,1",
   },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 < 4,3,2,1 > 10",
+  },
 ]
 `;
 
@@ -407,6 +491,18 @@ Array [
   Object {
     "active": false,
     "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatory 9 < 4,3,2,1 > 10",
   },
 ]
 `;
@@ -445,6 +541,18 @@ Array [
     "active": false,
     "message": "Observatoire 9 → 10 4,3,2,1",
   },
+  Object {
+    "active": false,
+    "message": "Observatoire 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatoire 9 → 10 4,3,2,1",
+  },
+  Object {
+    "active": false,
+    "message": "Observatoire 9 < 4,3,2,1 > 10",
+  },
 ]
 `;
 
@@ -482,6 +590,18 @@ Object {
     Object {
       "active": false,
       "message": "Observatory 9 → 10 4,3,2,1",
+    },
+    Object {
+      "active": false,
+      "message": "Observatory 9 → 10 4,3,2,1",
+    },
+    Object {
+      "active": false,
+      "message": "Observatory 9 → 10 4,3,2,1",
+    },
+    Object {
+      "active": false,
+      "message": "Observatory 9 < 4,3,2,1 > 10",
     },
   ],
   "result": Object {

--- a/test/unit/components/gb-investment.js
+++ b/test/unit/components/gb-investment.js
@@ -114,6 +114,9 @@ describe("GbInvestment", () => {
           gbi_ipg: 90,
           gbi_px: "foo",
           gbi_sx: "bar",
+          gbi_sn: "1",
+          gbi_dgbn: "0",
+          gbi_sl: "1",
           gbi_spx: "0",
           gbi_ssx: "0",
           gbi_p1: investorPercentageCustom[0],
@@ -141,6 +144,9 @@ describe("GbInvestment", () => {
     expect(wrapper.vm.investorPercentageGlobal).toBe(90);
     expect(wrapper.vm.prefix).toBe("foo");
     expect(wrapper.vm.suffix).toBe("bar");
+    expect(wrapper.vm.displayGbName).toBe(false);
+    expect(wrapper.vm.shortName).toBe(true);
+    expect(wrapper.vm.showLevel).toBe(true);
     expect(wrapper.vm.showPrefix).toBe(false);
     expect(wrapper.vm.showSuffix).toBe(false);
     expect(wrapper.vm.showSnipe).toBe(true);
@@ -180,6 +186,12 @@ describe("GbInvestment", () => {
               return "foo";
             case "gbSuffix":
               return "bar";
+            case "shortName":
+              return true;
+            case "displayGbName":
+              return false;
+            case "showLevel":
+              return true;
             case "root_investorPercentageCustom_0":
               return 92;
             case "root_investorPercentageCustom_1":
@@ -210,6 +222,9 @@ describe("GbInvestment", () => {
     expect(wrapper.vm.investorPercentageGlobal).toBe(90);
     expect(wrapper.vm.prefix).toBe("foo");
     expect(wrapper.vm.suffix).toBe("bar");
+    expect(wrapper.vm.displayGbName).toBe(false);
+    expect(wrapper.vm.shortName).toBe(true);
+    expect(wrapper.vm.showLevel).toBe(true);
     expect(wrapper.vm.showSnipe).toBe(true);
     expect(wrapper.vm.yourArcBonus).toBe(90);
     expect(wrapper.vm.investorPercentageCustom).toEqual(investorPercentageCustom);
@@ -398,6 +413,23 @@ describe("GbInvestment", () => {
     expect(wrapper.vm.errors.yourArcBonus).toBeFalsy();
   });
 
+  test('Change "displayGbName" value', () => {
+    const wrapper = factory();
+    const newValue = false;
+    expect(wrapper.vm.displayGbName).toBe(true);
+    wrapper.vm.displayGbName = newValue;
+    expect(wrapper.vm.displayGbName).toBe(newValue);
+    expect(wrapper.vm.$store.state.urlQueryNamespace["gbi"]["gbi_dgbn"]).toBe(newValue ? 1 : 0);
+    expect(wrapper.vm.$cookies.set.mock.calls[wrapper.vm.$cookies.set.mock.calls.length - 1]).toEqual([
+      "displayGbName",
+      false,
+      {
+        path: "/",
+        expires: wrapper.vm.$cookies.set.mock.calls[wrapper.vm.$cookies.set.mock.calls.length - 1][2].expires
+      }
+    ]);
+  });
+
   test('Change "prefix" value', () => {
     const wrapper = factory();
     const newValue = "foo";
@@ -425,6 +457,40 @@ describe("GbInvestment", () => {
     expect(wrapper.vm.$cookies.set.mock.calls[wrapper.vm.$cookies.set.mock.calls.length - 1]).toEqual([
       "gbSuffix",
       "bar",
+      {
+        path: "/",
+        expires: wrapper.vm.$cookies.set.mock.calls[wrapper.vm.$cookies.set.mock.calls.length - 1][2].expires
+      }
+    ]);
+  });
+
+  test('Change "shortName" value', () => {
+    const wrapper = factory();
+    const newValue = true;
+    expect(wrapper.vm.shortName).toBe(false);
+    wrapper.vm.shortName = newValue;
+    expect(wrapper.vm.shortName).toBe(newValue);
+    expect(wrapper.vm.$store.state.urlQueryNamespace["gbi"]["gbi_sn"]).toBe(newValue ? 1 : 0);
+    expect(wrapper.vm.$cookies.set.mock.calls[wrapper.vm.$cookies.set.mock.calls.length - 1]).toEqual([
+      "shortName",
+      true,
+      {
+        path: "/",
+        expires: wrapper.vm.$cookies.set.mock.calls[wrapper.vm.$cookies.set.mock.calls.length - 1][2].expires
+      }
+    ]);
+  });
+
+  test('Change "showLevel" value', () => {
+    const wrapper = factory();
+    const newValue = false;
+    expect(wrapper.vm.showLevel).toBe(true);
+    wrapper.vm.showLevel = newValue;
+    expect(wrapper.vm.showLevel).toBe(newValue);
+    expect(wrapper.vm.$store.state.urlQueryNamespace["gbi"]["gbi_sl"]).toBe(newValue ? 1 : 0);
+    expect(wrapper.vm.$cookies.set.mock.calls[wrapper.vm.$cookies.set.mock.calls.length - 1]).toEqual([
+      "showLevel",
+      newValue,
       {
         path: "/",
         expires: wrapper.vm.$cookies.set.mock.calls[wrapper.vm.$cookies.set.mock.calls.length - 1][2].expires
@@ -813,5 +879,11 @@ describe("GbInvestment", () => {
     expect(wrapper.vm.showSuffix).toBe(true);
     wrapper.vm.switchSuffix();
     expect(wrapper.vm.showSuffix).toBe(false);
+  });
+
+  test("Check 'getCustomArcBonus'", () => {
+    const wrapper = factory();
+    wrapper.vm.calculate();
+    expect(wrapper.vm.getCustomArcBonus).toBe(90.6);
   });
 });

--- a/test/unit/scripts/promotion-message-builder.js
+++ b/test/unit/scripts/promotion-message-builder.js
@@ -24,6 +24,8 @@ const results = [
     config: {
       prefix: "Your pseudo",
       suffix: "up in half hour",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: false,
       placeSeparator: " ",
@@ -36,6 +38,8 @@ const results = [
     config: {
       prefix: "Yoratheon",
       suffix: "up dans 30 min",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: false,
       placeSeparator: " ",
@@ -48,6 +52,8 @@ const results = [
     config: {
       prefix: "Your pseudo",
       suffix: "up in half hour",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: true,
       placeSeparator: " ",
@@ -60,6 +66,8 @@ const results = [
     config: {
       prefix: "Yoratheon",
       suffix: "up dans 30 min",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: true,
       placeSeparator: " ",
@@ -72,6 +80,8 @@ const results = [
     config: {
       prefix: "Yoratheon",
       suffix: "up dans 30 min",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: false,
       placeSeparator: " ",
@@ -84,6 +94,8 @@ const results = [
     config: {
       prefix: "Yoratheon",
       suffix: "up dans 30 min",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: true,
       placeSeparator: " ",
@@ -96,6 +108,8 @@ const results = [
     config: {
       prefix: "псевдонимы",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: false,
       placeSeparator: ",",
@@ -108,6 +122,8 @@ const results = [
     config: {
       prefix: "إسم مستعار",
       suffix: "",
+      displayGbName: true,
+      showLevel: true,
       useShortGbName: false,
       reversePlacesOrder: true,
       placeSeparator: ",",


### PR DESCRIPTION
Re-introduce option to show gb name and levels.

Add GB levels (cost and reward) of:
- Iron Age: 106 to 107
- Late Middle Ages: 142
- Colonial Age: 104
- Progressive Era: 172
- Tomorrow: 103
- Oceanic Future: 115
- Space Age: Mars: 84 to 89