### PR TITLE
Add levels of several ages

### DIFF
--- a/.scripts/config.json
+++ b/.scripts/config.json
@@ -1,11 +1,11 @@
 {
   "BronzeAge": 157,
-  "IronAge": 107,
+  "IronAge": 108,
   "EarlyMiddleAges": 133,
-  "HighMiddleAges": 99,
+  "HighMiddleAges": 101,
   "LateMiddleAges": 142,
   "ColonialAge": 104,
-  "IndustrialAge": 103,
+  "IndustrialAge": 106,
   "ProgressiveEra": 172,
   "ModernEra": 101,
   "PostmodernEra": 136,
@@ -15,5 +15,5 @@
   "ArcticFuture": 137,
   "OceanicFuture": 115,
   "VirtualFuture": 118,
-  "SpaceAgeMars": 89
+  "SpaceAgeMars": 101
 }

--- a/lib/foe-data/ages-cost/IndustrialAge.js
+++ b/lib/foe-data/ages-cost/IndustrialAge.js
@@ -103,5 +103,8 @@ module.exports = [
   { cost: 7291, reward: generateReward(1330) },
   { cost: 7474, reward: generateReward(1345) },
   { cost: 7660, reward: generateReward(1360) },
-  { cost: 7852, reward: generateReward(1375) }
+  { cost: 7852, reward: generateReward(1375) },
+  { cost: 8048, reward: generateReward(1395) },
+  { cost: 8249, reward: generateReward(1410) },
+  { cost: 8456, reward: generateReward(1425) }
 ];

--- a/lib/foe-data/ages-cost/IronAge.js
+++ b/lib/foe-data/ages-cost/IronAge.js
@@ -107,5 +107,6 @@ module.exports = [
   { cost: 5603, reward: generateReward(985) },
   { cost: 5743, reward: generateReward(995) },
   { cost: 5887, reward: generateReward(1010) },
-  { cost: 6034, reward: generateReward(1020) }
+  { cost: 6034, reward: generateReward(1020) },
+  { cost: 6185, reward: generateReward(1030) }
 ];

--- a/lib/foe-data/ages-cost/SpaceAgeMars.js
+++ b/lib/foe-data/ages-cost/SpaceAgeMars.js
@@ -89,5 +89,17 @@ module.exports = [
   { cost: 8165, reward: generateReward(1760) },
   { cost: 8369, reward: generateReward(1785) },
   { cost: 8578, reward: generateReward(1810) },
-  { cost: 8793, reward: generateReward(1835) }
+  { cost: 8793, reward: generateReward(1835) },
+  { cost: 9012, reward: generateReward(1860) },
+  { cost: 9238, reward: generateReward(1885) },
+  { cost: 9469, reward: generateReward(1910) },
+  { cost: 9705, reward: generateReward(1935) },
+  { cost: 9948, reward: generateReward(1960) },
+  { cost: 10197, reward: generateReward(1985) },
+  { cost: 10452, reward: generateReward(2010) },
+  { cost: 10713, reward: generateReward(2035) },
+  { cost: 10981, reward: generateReward(2060) },
+  { cost: 11255, reward: generateReward(2085) },
+  { cost: 11537, reward: generateReward(2110) },
+  { cost: 11825, reward: generateReward(2135) }
 ];

--- a/lib/foe-data/ages-cost/defaultCost.js
+++ b/lib/foe-data/ages-cost/defaultCost.js
@@ -99,5 +99,7 @@ module.exports = [
   { cost: 6788, reward: generateReward(1160) },
   { cost: 6957, reward: generateReward(1175) },
   { cost: 7131, reward: generateReward(1190) },
-  { cost: 7309, reward: generateReward(1200) }
+  { cost: 7309, reward: generateReward(1200) },
+  { cost: 7492, reward: generateReward(1215) },
+  { cost: 7679, reward: generateReward(1230) }
 ];


### PR DESCRIPTION
Add GB levels (cost and reward) of:
- Iron Age: 108
- High Middle Ages / No Age: 100 to 101
- Industrial Age: 104 to 106
- Space Age: Mars: 90 to 101