### PR TITLE
fix(cf-calculator): add a min value to 7 times the amount for the quests

### DIFF
--- a/components/cf-calculator/template.pug
+++ b/components/cf-calculator/template.pug
@@ -19,7 +19,17 @@ div
         b-select#your-age(v-model="yourAge" name="your-age" expanded)
           option(v-for="age in questData.ages" :value="age.key" :key="age.key" :selected="yourAge == age.key" :id="'option_' + age.key" autocomplete="off") {{$t('foe_data.age.' + age.key)}}
       b-field(:label="$t(i18nPrefix + 'block_cfc.coins_to_use')" label-for="coins" :type="haveError('coins')")
-        b-input#coins(type="number" min="0" v-model.number="coins" name="coins" autocomplete="off")
+        template(slot="label")
+          .media
+            span.media-content {{$t(i18nPrefix + 'block_cfc.coins_to_use')}}
+            div.media-right
+              b-tooltip.is-hidden-touch(type='is-dark' :label="$t(i18nPrefix + 'block_cfc.coins_supplies_info', { min: minCoins })" multilined)
+                span.icon
+                  i.far.fa-question-circle
+              b-tooltip.is-hidden-desktop(type='is-dark' :label="$t(i18nPrefix + 'block_cfc.coins_supplies_info', { min: minCoins })" multilined position="is-left")
+                span.icon
+                  i.far.fa-question-circle
+        b-input#coins(type="number" :min="minCoins" v-model.number="coins" name="coins" autocomplete="off")
       b-field(:label="$t(i18nPrefix + 'block_cfc.gb_plunder_goods')" label-for="goods" :type="haveError('goods')")
         b-input#goods(type="number" min="0" v-model.number="goods" name="goods" autocomplete="off")
       yes-no(v-show="checkSecondQuest" v-model="secondRq" :label="$t(i18nPrefix + 'block_cfc.second_rq')")
@@ -29,7 +39,17 @@ div
       b-field(:label="$t(i18nPrefix + 'block_cfc.your_cf_boost')" label-for="your-cf-boost" :type="haveError('yourCfBoost')")
         b-input#your-cf-boost(type="number" min="0" v-model.number="yourCfBoost" name="your-cf-boost" autocomplete="off")
       b-field(:label="$t(i18nPrefix + 'block_cfc.supplies_to_use')" label-for="supplies" :type="haveError('supplies')")
-        b-input#supplies(type="number" min="0" v-model.number="supplies" name="supplies" autocomplete="off")
+        template(slot="label")
+          .media
+            span.media-content {{$t(i18nPrefix + 'block_cfc.supplies_to_use')}}
+            div.media-right
+              b-tooltip.is-hidden-touch(type='is-dark' :label="$t(i18nPrefix + 'block_cfc.coins_supplies_info', { min: minSupplies })" multilined)
+                span.icon
+                  i.far.fa-question-circle
+              b-tooltip.is-hidden-desktop(type='is-dark' :label="$t(i18nPrefix + 'block_cfc.coins_supplies_info', { min: minSupplies })" multilined position="is-left")
+                span.icon
+                  i.far.fa-question-circle
+        b-input#supplies(type="number" :min="minSupplies" v-model.number="supplies" name="supplies" autocomplete="off")
       b-field(:label="$t(i18nPrefix + 'block_cfc.fp_by_24h')" label-for="fp-by-24h" :type="haveError('fpBy24h')")
         b-input#fp-by-24h(type="number" min="0" v-model.number="fpBy24h" name="fp-by-24h" autocomplete="off")
       b-field(v-show="checkSecondQuest && secondRq" :label="$t(i18nPrefix + 'block_cfc.supplies_gathered')" label-for="supplies-gathered" :type="haveError('suppliesGathered')")

--- a/lib/foe-compute-process/cf-calculator.js
+++ b/lib/foe-compute-process/cf-calculator.js
@@ -1,3 +1,5 @@
+import * as Errors from "../../scripts/errors";
+
 export default {
   /**
    * Compute the gains that can be expected to be statistically gained
@@ -18,6 +20,9 @@ export default {
    * All awards obtained statistically.
    */
   compute(age, yourCfBoost, coins, supplies, goods, fpBy24h, secondRq, suppliesGathered, otherRq, cumulativeQuest = 0) {
+    const funcName =
+      "compute(age, yourCfBoost, coins, supplies, goods, fpBy24h, secondRq, " +
+      "suppliesGathered, otherRq, cumulativeQuest = 0)";
     const cf_boost = yourCfBoost / 100;
     const coins_relation = Math.floor(coins / age.cost.coins);
     const supplies_relation = Math.floor(supplies / age.cost.supplies);
@@ -50,6 +55,22 @@ export default {
       if (cumulativeQuest <= 0) {
         return result;
       }
+    }
+
+    if (coins < 7 * age.cost.coins) {
+      throw new Errors.BoundExceededError({
+        type: Errors.AvailableBoundTypes["<"],
+        value: coins,
+        boundValue: 7 * age.cost.coins,
+        additionalMessage: `for parameter "coins" of ${funcName}`
+      });
+    } else if (supplies < 7 * age.cost.supplies) {
+      throw new Errors.BoundExceededError({
+        type: Errors.AvailableBoundTypes["<"],
+        value: supplies,
+        boundValue: 7 * age.cost.supplies,
+        additionalMessage: `for parameter "supplies" of ${funcName}`
+      });
     }
 
     let nb_quest =

--- a/locales/en.json
+++ b/locales/en.json
@@ -31,6 +31,7 @@
           "your_age": "Your Age",
           "your_cf_boost": "Your $t(foe_data.gb.Chateau_Frontenac) Boost",
           "coins_to_use": "Coins to use on UBQ",
+          "coins_supplies_info": "This value should be greater or equal than {{min}} because underneath we cannot guarantee any profit (statistically)",
           "supplies_to_use": "Supplies to use on UBQ",
           "gb_plunder_goods": "GB & Plunder Goods",
           "fp_by_24h": "24 Hour FP Production",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -32,6 +32,7 @@
           "your_cf_boost": "Le bonus de votre $t(foe_data.gb.Chateau_Frontenac)",
           "coins_to_use": "PO à utiliser dans la quête de Rinbin",
           "supplies_to_use": "Marchandises à utiliser dans la quête de Rinbin",
+          "coins_supplies_info": "Cette valeur doit être supérieure ou égale à {{min}} car en dessous on ne peut garantir aucun profit (statistiquement)",
           "gb_plunder_goods": "Ressources obtenues par les GMs et le pillage",
           "fp_by_24h": "Production de PF par 24h ",
           "other_rq": "Autre quête récurrente accomplie",


### PR DESCRIPTION
This is to prevent an infinite loop. When the value of coins or supplies
is lower than 7 times the amount for the quest, it is statistically not
possible to determine the profit.

Fix #258 