### PR TITLE
Add levels of several ages

### DIFF
--- a/.scripts/config.json
+++ b/.scripts/config.json
@@ -1,19 +1,19 @@
 {
   "BronzeAge": 157,
-  "IronAge": 111,
+  "IronAge": 114,
   "EarlyMiddleAges": 133,
-  "HighMiddleAges": 112,
-  "LateMiddleAges": 142,
-  "ColonialAge": 105,
+  "HighMiddleAges": 114,
+  "LateMiddleAges": 144,
+  "ColonialAge": 106,
   "IndustrialAge": 106,
-  "ProgressiveEra": 173,
+  "ProgressiveEra": 179,
   "ModernEra": 101,
   "PostmodernEra": 136,
-  "ContemporaryEra": 124,
+  "ContemporaryEra": 126,
   "Tomorrow": 104,
   "TheFuture": 183,
   "ArcticFuture": 137,
-  "OceanicFuture": 115,
+  "OceanicFuture": 116,
   "VirtualFuture": 120,
-  "SpaceAgeMars": 102
+  "SpaceAgeMars": 104
 }

--- a/lib/foe-data/ages-cost/ColonialAge.js
+++ b/lib/foe-data/ages-cost/ColonialAge.js
@@ -105,5 +105,6 @@ module.exports = [
   { cost: 7176, reward: generateReward(1280) },
   { cost: 7355, reward: generateReward(1295) },
   { cost: 7539, reward: generateReward(1310) },
-  { cost: 7727, reward: generateReward(1325) }
+  { cost: 7727, reward: generateReward(1325) },
+  { cost: 7920, reward: generateReward(1345) }
 ];

--- a/lib/foe-data/ages-cost/ContemporaryEra.js
+++ b/lib/foe-data/ages-cost/ContemporaryEra.js
@@ -124,5 +124,7 @@ module.exports = [
   { cost: 13641, reward: generateReward(2065) },
   { cost: 13982, reward: generateReward(2085) },
   { cost: 14332, reward: generateReward(2105) },
-  { cost: 14690, reward: generateReward(2125) }
+  { cost: 14690, reward: generateReward(2125) },
+  { cost: 15057, reward: generateReward(2150) },
+  { cost: 15434, reward: generateReward(2170) }
 ];

--- a/lib/foe-data/ages-cost/IronAge.js
+++ b/lib/foe-data/ages-cost/IronAge.js
@@ -111,5 +111,8 @@ module.exports = [
   { cost: 6185, reward: generateReward(1030) },
   { cost: 6340, reward: generateReward(1040) },
   { cost: 6498, reward: generateReward(1055) },
-  { cost: 6660, reward: generateReward(1065) }
+  { cost: 6660, reward: generateReward(1065) },
+  { cost: 6827, reward: generateReward(1075) },
+  { cost: 6998, reward: generateReward(1090) },
+  { cost: 7173, reward: generateReward(1100) }
 ];

--- a/lib/foe-data/ages-cost/LateMiddleAges.js
+++ b/lib/foe-data/ages-cost/LateMiddleAges.js
@@ -142,5 +142,7 @@ module.exports = [
   { cost: 16923, reward: generateReward(1745) },
   { cost: 17347, reward: generateReward(1760) },
   { cost: 17780, reward: generateReward(1775) },
-  { cost: 18225, reward: generateReward(1790) }
+  { cost: 18225, reward: generateReward(1790) },
+  { cost: 18680, reward: generateReward(1805) },
+  { cost: 19147, reward: generateReward(1820) }
 ];

--- a/lib/foe-data/ages-cost/OceanicFuture.js
+++ b/lib/foe-data/ages-cost/OceanicFuture.js
@@ -115,5 +115,6 @@ module.exports = [
   { cost: 14398, reward: generateReward(2240) },
   { cost: 14758, reward: generateReward(2265) },
   { cost: 15127, reward: generateReward(2290) },
-  { cost: 15505, reward: generateReward(2310) }
+  { cost: 15505, reward: generateReward(2310) },
+  { cost: 15893, reward: generateReward(2335) }
 ];

--- a/lib/foe-data/ages-cost/ProgressiveEra.js
+++ b/lib/foe-data/ages-cost/ProgressiveEra.js
@@ -173,5 +173,11 @@ module.exports = [
   { cost: 43142, reward: generateReward(2665) },
   { cost: 44221, reward: generateReward(2685) },
   { cost: 45326, reward: generateReward(2705) },
-  { cost: 46459, reward: generateReward(2720) }
+  { cost: 46459, reward: generateReward(2720) },
+  { cost: 47621, reward: generateReward(2740) },
+  { cost: 48811, reward: generateReward(2760) },
+  { cost: 50032, reward: generateReward(2780) },
+  { cost: 51282, reward: generateReward(2800) },
+  { cost: 52564, reward: generateReward(2815) },
+  { cost: 53878, reward: generateReward(2835) }
 ];

--- a/lib/foe-data/ages-cost/SpaceAgeMars.js
+++ b/lib/foe-data/ages-cost/SpaceAgeMars.js
@@ -102,5 +102,7 @@ module.exports = [
   { cost: 11255, reward: generateReward(2085) },
   { cost: 11537, reward: generateReward(2110) },
   { cost: 11825, reward: generateReward(2135) },
-  { cost: 12121, reward: generateReward(2160) }
+  { cost: 12121, reward: generateReward(2160) },
+  { cost: 12424, reward: generateReward(2185) },
+  { cost: 12734, reward: generateReward(2215) }
 ];

--- a/lib/foe-data/ages-cost/defaultCost.js
+++ b/lib/foe-data/ages-cost/defaultCost.js
@@ -103,5 +103,7 @@ module.exports = [
   { cost: 7492, reward: generateReward(1215) },
   { cost: 7679, reward: generateReward(1230) },
   { cost: 7871, reward: generateReward(1240) },
-  { cost: 8068, reward: generateReward(1255) }
+  { cost: 8068, reward: generateReward(1255) },
+  { cost: 8270, reward: generateReward(1270) },
+  { cost: 8477, reward: generateReward(1280) }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -2844,6 +2844,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "dev": true
+    },
     "@types/lodash": {
       "version": "4.14.138",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
@@ -2904,6 +2910,27 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
       "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
       "dev": true
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-scope": "^4.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      }
     },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.0.0",
@@ -9028,6 +9055,15 @@
         }
       }
     },
+    "eslint-plugin-jest": {
+      "version": "22.17.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.17.0.tgz",
+      "integrity": "sha512-WT4DP4RoGBhIQjv+5D0FM20fAdAUstfYAf/mkufLNTojsfgzc5/IYW22cIg/Q4QBavAZsROQlqppiWDpFZDS8Q==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^1.13.0"
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
@@ -13919,6 +13955,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+      "dev": true
     },
     "lodash.unionby": {
       "version": "4.8.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-friendly-formatter": "^4.0.1",
     "eslint-import-resolver-webpack": "^0.11.1",
     "eslint-loader": "^3.0.0",
+    "eslint-plugin-jest": "^22.17.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-testcafe": "^0.2.1",
     "eslint-plugin-vue": "^5.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,6 +1596,11 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/json-schema@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
+  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+
 "@types/lodash@^4.14.72":
   version "4.14.119"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.119.tgz#be847e5f4bc3e35e46d041c394ead8b603ad8b39"
@@ -1657,6 +1662,23 @@
   integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/experimental-utils@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
+  integrity sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "1.13.0"
+    eslint-scope "^4.0.0"
+
+"@typescript-eslint/typescript-estree@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz#8140f17d0f60c03619798f1d628b8434913dc32e"
+  integrity sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
   version "1.0.0"
@@ -5964,6 +5986,13 @@ eslint-plugin-import@^2.17.1:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
+eslint-plugin-jest@^22.17.0:
+  version "22.17.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.17.0.tgz#dc170ec8369cd1bff9c5dd8589344e3f73c88cf6"
+  integrity sha512-WT4DP4RoGBhIQjv+5D0FM20fAdAUstfYAf/mkufLNTojsfgzc5/IYW22cIg/Q4QBavAZsROQlqppiWDpFZDS8Q==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^1.13.0"
+
 eslint-plugin-jest@^22.4.1:
   version "22.6.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.6.4.tgz#2895b047dd82f90f43a58a25cf136220a21c9104"
@@ -9099,6 +9128,11 @@ lodash.templatesettings@^4.0.0:
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
 lodash.unionby@^4.8.0:
   version "4.8.0"


### PR DESCRIPTION
Add GB levels (cost and reward) of:
- Iron Age: 112 to 114
- High Middle Ages / No Age: 113 to 114
- Late Middle Ages: 143 to 144
- Colonial Age: 106
- Progressive Era: 174 to 179
- Contemporary Era: 125 to 126
- Oceanic Future: 116
- Space Age: Mars: 103 to 104