### PR TITLE
style: remove spin arrows

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -356,3 +356,12 @@ div.navbar-brand .field {
 input, textarea {
   margin-bottom: 0 !important;
 }
+
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+}
+input[type=number] {
+  -moz-appearance:textfield;
+  appearance: none;
+}


### PR DESCRIPTION
Remove built-in browsers spin arrows since it's redundant
with +/- buttons.